### PR TITLE
Fixes out of tree builds

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -29,6 +29,7 @@
 # Self tests.
 
 AM_LDFLAGS = -no-install
+AM_CPPFLAGS = -I$(top_srcdir)
 LDADD = ../libyubikey.la
 
 check_PROGRAMS = selftest


### PR DESCRIPTION
seems like I don't have direct access to the yubico-c tree, but please pull this change as it fixes builds where srcdir != builddir.
