### PR TITLE
Declare that the passed in array need to be 33 bytes

### DIFF
--- a/yktoken.c
+++ b/yktoken.c
@@ -45,7 +45,8 @@ yubikey_parse (const uint8_t token[32],
 
 void
 yubikey_generate (yubikey_token_t token,
-		  const uint8_t key[YUBIKEY_KEY_SIZE], char out[32])
+		  const uint8_t key[YUBIKEY_KEY_SIZE],
+		  char out[YUBIKEY_OTP_SIZE + 1])
 {
   yubikey_aes_encrypt ((uint8_t *) token, key);
   yubikey_modhex_encode (out, (const char *) token, YUBIKEY_KEY_SIZE);

--- a/yubikey.h
+++ b/yubikey.h
@@ -80,7 +80,7 @@ extern "C"
 /* Generate OTP */
   extern void yubikey_generate (yubikey_token_t token,
 				const uint8_t key[YUBIKEY_KEY_SIZE],
-				char out[YUBIKEY_OTP_SIZE]);
+				char out[YUBIKEY_OTP_SIZE + 1]);
 
 #define yubikey_counter(ctr) ((ctr) & 0x7FFF)
 #define yubikey_capslock(ctr) ((ctr) & 0x8000)


### PR DESCRIPTION
The _yubikey_encode() function null terminates the buffer.

If one tries to pass in a 32 byte buffer with sanitizers turned on you get:

```
=================================================================
==796547==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7fff71da27e0 at pc 0x7f733efbe990 bp 0x7fff71da2520 sp 0x7fff71da2518
WRITE of size 1 at 0x7fff71da27e0 thread T0
    #0 0x7f733efbe98f in _yubikey_encode (/user/kode/yubico-c/.libs/libyubikey.so.0+0x798f)
    #1 0x7f733efbf20b in yubikey_modhex_encode (/user/kode/yubico-c/.libs/libyubikey.so.0+0x820b)
    #2 0x4c3bce in main (/user/kode/yubico-c/tests/selftest+0x4c3bce)
    #3 0x7f733ec270b2 in __libc_start_main /build/glibc-YYA7BZ/glibc-2.31/csu/../csu/libc-start.c:308:16
    #4 0x41b39d in _start (/user/kode/yubico-c/tests/selftest+0x41b39d)

Address 0x7fff71da27e0 is located in stack of thread T0 at offset 352 in frame
    #0 0x4c31df in main (/user/kode/yubico-c/tests/selftest+0x4c31df)

  This frame has 4 object(s):
    [32, 96) 'buf'
    [128, 192) 'hex_serial'
    [224, 288) 'modhex_serial'
    [320, 352) 'out1' <== Memory access at offset 352 overflows this variable
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-buffer-overflow (/user/kode/yubico-c/.libs/libyubikey.so.0+0x798f) in _yubikey_encode
Shadow bytes around the buggy address:
  0x10006e3ac4a0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10006e3ac4b0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10006e3ac4c0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10006e3ac4d0: f1 f1 f1 f1 00 00 00 00 00 00 00 00 f2 f2 f2 f2
  0x10006e3ac4e0: 00 00 00 00 00 00 00 00 f2 f2 f2 f2 00 00 00 00
=>0x10006e3ac4f0: 00 00 00 00 f2 f2 f2 f2 00 00 00 00[f3]f3 f3 f3
  0x10006e3ac500: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10006e3ac510: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10006e3ac520: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10006e3ac530: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10006e3ac540: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==796547==ABORTING
```