### PR TITLE
fuzz: add fuzzing for the 11 exposed functions

### DIFF
--- a/.github/workflows/linux_fuzz.yml
+++ b/.github/workflows/linux_fuzz.yml
@@ -1,0 +1,36 @@
+name: fuzzer
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04]
+        cc: [clang-10]
+    steps:
+    - uses: actions/checkout@v1
+    - name: Dependencies
+      env:
+        CC: ${{ matrix.cc }}
+      run: |
+        sudo apt -q update
+        sudo apt install -q -y autoconf automake libtool pkg-config \
+          libfido2-dev libpam-dev gengetopt
+          sudo apt install -q -y ${CC%-*}-tools-${CC#clang-}
+    - name: Fuzz
+      env:
+        CC: ${{ matrix.cc }}
+      run: |
+        autoreconf --install
+        ./configure CC=${CC} CFLAGS="-fsanitize=address,leak,undefined" \
+          --disable-documentation
+        make
+        make -C fuzz
+        curl --retry 4 -s -o corpus.tgz \
+           https://storage.googleapis.com/kroppkaka/corpus/yubico-c.corpus.tgz
+        tar xzf corpus.tgz
+        fuzz/fuzz_libyubikey -reload=30 -print_pcs=1 \
+           -print_funcs=30 -timeout=10 -runs=1 corpus

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -8,6 +8,7 @@ on:
 env:
   SCAN_IMG:
    yubico-yes-docker-local.jfrog.io/static-code-analysis/c:v1
+  COMPILE_DEPS: "xsltproc"
 
 jobs:
   build:

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ ykgenerate
 ykgenerate.1
 ykparse
 ykparse.1
+fuzz/Makefile
+fuzz/fuzz_libyubikey

--- a/configure.ac
+++ b/configure.ac
@@ -72,6 +72,21 @@ AC_ARG_ENABLE([gcc-warnings],
   [gl_gcc_warnings=no]
 )
 
+AC_CACHE_CHECK([for clang],
+        _cv_clang,[
+        AC_TRY_COMPILE([], [
+                #ifdef __clang__
+                #else
+                #error "NOT CLANG"
+                #endif
+                return 0;
+        ],
+        [_cv_clang=yes],
+        [_cv_clang=no],
+        [])
+])
+AM_CONDITIONAL([COMPILER_CLANG], [test "$_cv_clang" = yes])
+
 if test "$gl_gcc_warnings" = yes; then
   nw="$nw -Wsystem-headers"         # Don't let system headers trigger warnings
   nw="$nw -Wpadded"                 # Struct's arenot padded
@@ -95,6 +110,11 @@ AC_CONFIG_FILES([
   tests/Makefile
   yubico-c.pc
 ])
+
+# Are we running with clang
+if test "$_cv_clang" = "yes"; then
+   AC_CONFIG_FILES([fuzz/Makefile])
+fi
 AC_OUTPUT
 
 AC_MSG_NOTICE([summary of build options:

--- a/fuzz/Makefile.am
+++ b/fuzz/Makefile.am
@@ -1,0 +1,12 @@
+# Copyright (C) 2020 Yubico AB - See COPYING
+
+AM_CPPFLAGS = -I$(srcdir)/.. -Wno-pointer-sign -g
+AM_CPPFLAGS+=-fsanitize=fuzzer,address,signed-integer-overflow
+AM_CPPFLAGS+=-fno-sanitize-recover=all
+
+fuzz_libyubikey_SOURCES = fuzz_libyubikey.c
+
+fuzz_libyubikey_LDADD = ../.libs/libyubikey.a
+fuzz_libyubikey_LDFLAGS = -fsanitize=fuzzer,address,signed-integer-overflow
+
+bin_PROGRAMS = fuzz_libyubikey

--- a/fuzz/coverage.sh
+++ b/fuzz/coverage.sh
@@ -1,0 +1,19 @@
+#!/bin/sh -eux
+
+make clean
+make -C .. clean
+make CFLAGS="-fprofile-instr-generate -fcoverage-mapping" -C ..
+make CFLAGS="-fprofile-instr-generate -fcoverage-mapping"
+if [ ! -e "corpus" ]; then
+    curl --retry 4 -s -o corpus.tgz https://storage.googleapis.com/kroppkaka/corpus/yubico-c.corpus.tgz
+    tar xzf corpus.tgz
+fi
+./fuzz_libyubikey -runs=1 -dump_coverage=1 corpus
+llvm-profdata merge -sparse *.profraw -o default.profdata
+
+llvm-cov report -show-functions -instr-profile=default.profdata fuzz_libyubikey ../*.c fuzz_libyubikey.c
+
+# other report alternatives for convenience:
+#llvm-cov report -use-color=false -instr-profile=default.profdata fuzz_libyubikey
+#llvm-cov show -format=html -tab-size=8 -instr-profile=default.profdata -output-dir=report fuzz_libyubikey
+#llvm-cov show fuzz_libyubikey -instr-profile=default.profdata --show-line-counts-or-regions -format=html > report.html

--- a/fuzz/fuzz_libyubikey.c
+++ b/fuzz/fuzz_libyubikey.c
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2020 Yubico AB - See COPYING
+ */
+#include <stdio.h>
+
+#include "yubikey.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+
+  /* libyubikey has 11 functions that require no state, lets
+   * just hammer on them. Initial seeds can be extracted from
+   * the unit tests, apply selftest.c.patch to unit test and run
+   * it to generate initial seeds if not using the included corpus.
+   */
+
+  char buf[4096] = {0};
+  char buf2[sizeof(buf) * 2 + 1]; /* hex encoded buf + \0 */
+  /* - 2 below is one byte to choose action and one byte to keep
+   * the buf array null terminated no matter what. */
+  if (size > sizeof(buf) - 2 || !data || size <= 1) {
+    return -1;
+  }
+
+  const char *ptr = data + 1;
+  size -= 1;
+
+  switch(data[0]) {
+  case 1:
+    yubikey_modhex_encode(buf2, ptr, size);
+    break;
+  case 2:
+    memcpy(buf, ptr, size);
+    yubikey_modhex_decode(buf2, buf, sizeof(buf2));
+    break;
+  case 3:
+    memcpy(buf, ptr, size);
+    yubikey_modhex_p(buf);
+    break;
+  case 4:
+    memcpy(buf, ptr, size);
+    yubikey_hex_p(buf);
+    break;
+  case 5:
+    yubikey_hex_encode(buf2, ptr, size);
+    break;
+  case 6:
+    memcpy(buf, ptr, size);
+    yubikey_hex_decode(buf2, buf, sizeof(buf2));
+    break;
+  case 7:
+    if (size > YUBIKEY_KEY_SIZE) {
+      memcpy(buf, ptr, size);
+      yubikey_aes_decrypt(buf + YUBIKEY_KEY_SIZE, buf);
+    }
+    break;
+  case 8:
+    if (size > YUBIKEY_KEY_SIZE) {
+      memcpy(buf, ptr, size);
+      yubikey_aes_encrypt(buf + YUBIKEY_KEY_SIZE, buf);
+    }
+    break;
+  case 9:
+    if (size > YUBIKEY_KEY_SIZE + sizeof(yubikey_token_st)) {
+      yubikey_token_st st;
+      memcpy((void*)&st, ptr + YUBIKEY_KEY_SIZE, sizeof(yubikey_token_st));
+      yubikey_generate ((void*)&st, ptr, buf);
+    }
+    break;
+  case 10:
+#define TOKEN_HEX_LENGTH YUBIKEY_KEY_SIZE * 2
+    if (size > (YUBIKEY_KEY_SIZE * 3) + sizeof(yubikey_token_st)) {
+      yubikey_token_st st = {0};
+      memcpy(buf, ptr, TOKEN_HEX_LENGTH);
+      buf[TOKEN_HEX_LENGTH] = '\0';
+      yubikey_parse ((const uint8_t*)buf, (void*)ptr + TOKEN_HEX_LENGTH, &st);
+    }
+    break;
+  case 11:
+    yubikey_crc16((const uint8_t*)ptr, size);
+    break;
+  }
+
+  return 0;
+}

--- a/fuzz/selftest.c.patch
+++ b/fuzz/selftest.c.patch
@@ -1,0 +1,159 @@
+diff --git a/tests/selftest.c b/tests/selftest.c
+index eabed81..cb51c9f 100644
+--- a/tests/selftest.c
++++ b/tests/selftest.c
+@@ -34,6 +34,27 @@
+ #include <stdio.h>
+ #include <assert.h>
+ 
++#include <sys/types.h>
++#include <sys/stat.h>
++#include <fcntl.h>
++#include <unistd.h>
++
++void create_seed(char* name, char* data, size_t size)
++{
++  char full_name[1024] = {0};
++  for (char i = 0; i < 13; ++i) {
++    sprintf(full_name, "seed/%d_%s", i, name);
++    int fd = open(full_name, O_WRONLY|O_CREAT, 00700);
++    if (fd != -1) {
++      write(fd, &i, 1);
++      write(fd, data, size);
++      close(fd);
++    }
++    else
++      perror("open");
++  }
++}
++
+ static void
+ modhex_test1 (void)
+ {
+@@ -41,6 +62,7 @@ modhex_test1 (void)
+   char buf2[1024];
+ 
+   yubikey_modhex_encode (buf, "test", 4);
++  create_seed(__FUNCTION__, "test", 5);
+   printf ("modhex-encode(\"test\") = %s\n", buf);
+   assert (strcmp (buf, "ifhgieif") == 0);
+   printf ("Modhex-1.1 success\n");
+@@ -59,6 +81,7 @@ modhex_test2 (void)
+   int rc;
+ 
+   strcpy (buf, "cbdefghijklnrtuv");
++  create_seed(__FUNCTION__, "cbdefghijklnrtuv", sizeof("cbdefghijklnrtuv"));
+   rc = yubikey_modhex_p (buf);
+   printf ("modhex-p(\"%s\") = %d\n", buf, rc);
+   assert (rc == 1);
+@@ -72,6 +95,7 @@ modhex_test3 (void)
+   int rc;
+ 
+   strcpy (buf, "cbdef0ghijklnrtuv");
++  create_seed(__FUNCTION__, "cbdef0ghijklnrtuv", sizeof("cbdef0ghijklnrtuv"));
+   rc = yubikey_modhex_p (buf);
+   printf ("modhex-p(\"%s\") = %d\n", buf, rc);
+   assert (rc == 0);
+@@ -85,6 +109,7 @@ hex_test1 (void)
+   int rc;
+ 
+   strcpy (buf, "0123Xabc");
++  create_seed(__FUNCTION__, "0123Xabc", sizeof("0123Xabc"));
+   rc = yubikey_hex_p (buf);
+   printf ("hex-p(\"%s\") = %d\n", buf, rc);
+   assert (rc == 0);
+@@ -103,6 +128,7 @@ hex_test2 (void)
+   printf ("Hex-2.1 success\n");
+ 
+   printf ("hex-decode(\"%s\") = ", buf);
++  create_seed(__FUNCTION__, buf, strlen(buf) + 1);
+   yubikey_hex_decode (buf2, buf, sizeof (buf2));
+   printf ("%.*s\n", 4, buf2);
+   assert (memcmp (buf2, "test", 4) == 0);
+@@ -116,6 +142,7 @@ hex_test3 (void)
+   int rc;
+ 
+   strcpy (buf, "0123456789abcdef");
++  create_seed(__FUNCTION__, buf, strlen(buf) + 1);
+   rc = yubikey_hex_p (buf);
+   printf ("hex-p(\"%s\") = %d\n", buf, rc);
+   assert (rc == 1);
+@@ -129,6 +156,7 @@ hex_test4 (void)
+   int rc;
+ 
+   strcpy (buf, "0123Xabc");
++  create_seed(__FUNCTION__, buf, strlen(buf)+1);
+   rc = yubikey_hex_p (buf);
+   printf ("hex-p(\"%s\") = %d\n", buf, rc);
+   assert (rc == 0);
+@@ -143,6 +171,7 @@ hex_test5 (void)
+   char cmp[1024];
+ 
+   strcpy (buf, "a2c2a");
++  create_seed(__FUNCTION__, buf, strlen(buf)+1);
+   memset (buf2, 0, sizeof (buf2));
+   yubikey_hex_decode (buf2, buf, sizeof (buf2));
+   printf ("hex-decode(\"%s\") = %x%x%x\n", buf, buf2[0], buf2[1], buf2[2]);
+@@ -161,6 +190,7 @@ hex_test6 (void)
+   char cmp[1024];
+ 
+   strcpy (buf, "aGH2c2");
++  create_seed(__FUNCTION__, "test", 4);
+   memset (buf2, 0, sizeof (buf2));
+   yubikey_hex_decode (buf2, buf, sizeof (buf2));
+   printf ("hex-decode(\"%s\") = %x%x%x\n", \
+@@ -181,6 +211,11 @@ aes_test1 (void)
+ 
+   memcpy (buf, "0123456789abcdef\0", 17);
+   memcpy (key, "abcdef0123456789\0", 17);
++
++  uint8_t buffo[1024];
++  memcpy(buffo, key, 16);
++  memcpy(buffo+16, buf, 17);
++  create_seed(__FUNCTION__, buffo, strlen(buffo)+1);
+   printf ("aes-decrypt (data=%s, key=%s)\n => ", (char *) buf, (char *) key);
+   yubikey_aes_decrypt (buf, key);
+   for (i = 0; i < 16; i++)
+@@ -191,7 +226,7 @@ aes_test1 (void)
+ 		  "\x83\x8a\x46\x7f\x34\x63\x95\x51"
+ 		  "\x75\x5b\xd3\x2a\x4a\x2f\x15\xe1", 16) == 0);
+   printf ("AES-1.1 success\n");
+-
++  create_seed("aes_test1v2", buf, 16);
+   yubikey_aes_encrypt (buf, key);
+   assert (memcmp (buf, "0123456789abcdef", 16) == 0);
+   printf ("AES-1.2 success\n");
+@@ -209,13 +244,15 @@ otp_test1 (void)
+   memcpy ((void *) &tok,
+ 	  "\x16\xe1\xe5\xd9\xd3\x99\x10\x04\x45\x20\x07\xe3\x02\x00\x00", 16);
+   memcpy (key, "abcdef0123456789", 16);
+-
++  create_seed(__FUNCTION__, (void *) &tok, 16);
+   yubikey_generate ((void *) &tok, key, out);
+   yubikey_parse ((uint8_t *) out, key, &tok);
+ 
+   assert (memcmp (&tok,
+ 		  "\x16\xe1\xe5\xd9\xd3\x99\x10\x04\x45\x20\x07\xe3\x02\x00\x00",
+ 		  16) == 0);
++  create_seed("otp_test1v2",
++	      "\x16\xe1\xe5\xd9\xd3\x99\x10\x04\x45\x20\x07\xe3\x02\x00\x00", 16);
+   printf ("OTP-1 success\n");
+ }
+ 
+@@ -327,7 +364,7 @@ otp_testvectors (void)
+     assert (memcmp(&tok, &vectors[i].tok, sizeof(yubikey_token_st)) == 0);
+   }
+ }
+-
++#include <limits.h>
+ int
+ main (void)
+ {
+@@ -348,5 +385,7 @@ main (void)
+   crc_test4 ();
+   otp_testvectors ();
+ 
++  create_seed("another_hex_test", "aaaa", sizeof("aaaa"));
++
+   return 0;
+ }


### PR DESCRIPTION
As part of reducing the `risk` associated with our c projects, adding dynamic analysis is one tick in box that will reduce the overall risk score for that project. This fuzzing harness reaches 100% coverage and will run on push and pull request in a Github Action workflow with the corpus generated during development. The corpus tarball lives in a GCS bucket (gs://kroppkaka).

```
File '/user/kode/yubico-c/ykaes.c':
Name                        Regions    Miss   Cover     Lines    Miss   Cover
-----------------------------------------------------------------------------
yubikey_aes_decrypt              28       0 100.00%        91       0 100.00%
yubikey_aes_encrypt              20       0 100.00%        77       0 100.00%
ykaes.c:xtime                     3       0 100.00%         3       0 100.00%
-----------------------------------------------------------------------------
TOTAL                            51       0 100.00%       171       0 100.00%

File '/user/kode/yubico-c/ykcrc.c':
Name                        Regions    Miss   Cover     Lines    Miss   Cover
-----------------------------------------------------------------------------
yubikey_crc16                     8       0 100.00%        18       0 100.00%
-----------------------------------------------------------------------------
TOTAL                             8       0 100.00%        18       0 100.00%

File '/user/kode/yubico-c/ykhex.c':
Name                        Regions    Miss   Cover     Lines    Miss   Cover
-----------------------------------------------------------------------------
yubikey_hex_encode                1       0 100.00%         3       0 100.00%
yubikey_hex_decode                1       0 100.00%         3       0 100.00%
yubikey_hex_p                     1       0 100.00%         3       0 100.00%
yubikey_modhex_encode             1       0 100.00%         3       0 100.00%
yubikey_modhex_decode             1       0 100.00%         3       0 100.00%
yubikey_modhex_p                  1       0 100.00%         3       0 100.00%
ykhex.c:_yubikey_encode           3       0 100.00%         9       0 100.00%
ykhex.c:_yubikey_decode          16       0 100.00%        29       0 100.00%
ykhex.c:_yubikey_p                7       0 100.00%         7       0 100.00%
-----------------------------------------------------------------------------
TOTAL                            32       0 100.00%        63       0 100.00%

File '/user/kode/yubico-c/yktoken.c':
Name                        Regions    Miss   Cover     Lines    Miss   Cover
-----------------------------------------------------------------------------
yubikey_parse                     1       0 100.00%         5       0 100.00%
yubikey_generate                  2       0 100.00%         4       0 100.00%
-----------------------------------------------------------------------------
TOTAL                             3       0 100.00%         9       0 100.00%

File '/user/kode/yubico-c/fuzz/fuzz_libyubikey.c':
Name                        Regions    Miss   Cover     Lines    Miss   Cover
-----------------------------------------------------------------------------
LLVMFuzzerTestOneInput           41       0 100.00%        77       0 100.00%
-----------------------------------------------------------------------------
TOTAL                            41       0 100.00%        77       0 100.00%
```