### PR TITLE
Fix test vector input "test"

### DIFF
--- a/test-vectors.txt
+++ b/test-vectors.txt
@@ -43,7 +43,7 @@ More test vectors:
 INPUT:     test
 ENCODE:    ifhgieif
 
-INPUT:     test
+INPUT:     foobar
 ENCODE:    hhhvhvhdhbid
 
 AES-ECB


### PR DESCRIPTION
There were two test vectors with input "test", but with different output. Decoding the encoded string showed that the input should be "foobar" instead of "test".