### PR TITLE
fix typo

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -89,7 +89,7 @@ AM_CONDITIONAL([COMPILER_CLANG], [test "$_cv_clang" = yes])
 
 if test "$gl_gcc_warnings" = yes; then
   nw="$nw -Wsystem-headers"         # Don't let system headers trigger warnings
-  nw="$nw -Wpadded"                 # Struct's arenot padded
+  nw="$nw -Wpadded"                 # Struct's are not padded
   nw="$nw -Wc++-compat"             # We don't care strongly about C++ compilers
   nw="$nw -Wtraditional"            # Warns on #elif which we use often
   nw="$nw -Wtraditional-conversion" # Too many warnings for now


### PR DESCRIPTION
Dumped repo strings exposed a solitary innocuous typo in `configure.ac`.

Incidentally, it looks like a `configure` script is not generated to be included in the tagged package tarballs.